### PR TITLE
fix: libncurses6-dev not found

### DIFF
--- a/include/mysql.sh
+++ b/include/mysql.sh
@@ -69,8 +69,8 @@ common_install() {
     if check_sys packageManager apt; then
         # Replace some dependencies on Ubuntu 24.04
         if ubuntuversion 24; then
-            apt_list=(${apt_list[@]/#libncurses5/libncurses6})
             apt_list=(${apt_list[@]/#libncurses5-dev/libncurses-dev})
+            apt_list=(${apt_list[@]/#libncurses5/libncurses6})
             apt_list=(${apt_list[@]/#libaio1/libaio1t64})
         fi
         for depend in ${apt_list[@]}; do


### PR DESCRIPTION
We should first change libncurses5-dev to libncurses-dev, then change libncurses5 to libncurses6.

Fix: #279 